### PR TITLE
Bot token not needed

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,1 @@
-TOKEN=
 PORT=3000

--- a/index.ts
+++ b/index.ts
@@ -14,7 +14,7 @@ let cache: {
 
 app.get('/', async (_, res) => {
 	if(!cache.data || Date.now() - cache.lastUpdated > 30000) {
-		const r = await fetch('https://discord.com/api/v8/sticker-packs/directory-v2/758482250722574376?with_store_listings=true', {headers: {authorization: `Bot ${token}`}})
+		const r = await fetch('https://discord.com/api/v8/sticker-packs/directory-v2/758482250722574376?with_store_listings=true')
 		cache.data = await r.json()
 		cache.lastUpdated = Date.now()
 	}

--- a/index.ts
+++ b/index.ts
@@ -5,7 +5,6 @@ import path from 'path'
 const app = express()
 app.set('view engine', 'ejs')
 
-const token = process.env.TOKEN
 
 let cache: {
 	lastUpdated?: number


### PR DESCRIPTION
You don't need to have a bot token for viewing stickers. 
- Updated `.env.example` because the token isn't needed.
- Updated `index.ts` to remove headers.