### PR TITLE
Add wrapping to columns

### DIFF
--- a/style.sass
+++ b/style.sass
@@ -27,6 +27,9 @@
 .section
 	overflow: auto
 
+.wrap
+	flex-wrap: wrap
+
 @import "node_modules/bulma/sass/utilities/_all"
 
 $scheme-main: #141414

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -51,7 +51,7 @@
 		</section>
 		<section class="section pt-0">
 			<div class="container is-fluid">
-				<div class="columns">
+				<div class="columns wrap">
 					<% data.sticker_packs?.map(pack => { %>
 						<div class="column">
 							<picture>


### PR DESCRIPTION
The columns currently overflow in the x axis, I suggest that we put a flex wrap on the columns containers to split it up automatically.